### PR TITLE
Fix React hook order on reports page

### DIFF
--- a/app/admin/reports/page.tsx
+++ b/app/admin/reports/page.tsx
@@ -28,6 +28,32 @@ export default function AdminReportsPage() {
     setIsLoading(false)
   }, [router])
 
+  useEffect(() => {
+    const fetchReport = async () => {
+      try {
+        setReportLoading(true)
+        const params = new URLSearchParams()
+        if (filters.startDate) params.append("startDate", filters.startDate)
+        if (filters.endDate) params.append("endDate", filters.endDate)
+        if (filters.branchId) params.append("branchId", filters.branchId)
+
+        const res = await fetch(`/api/reports?${params.toString()}`)
+        const data = await res.json()
+        setSummary(data.summary)
+        setServiceStats(data.serviceStats || [])
+        setBranchStats(data.branchStats || [])
+      } catch (error) {
+        console.error("Failed to fetch report:", error)
+      } finally {
+        setReportLoading(false)
+      }
+    }
+
+    if (isAuthenticated) {
+      fetchReport()
+    }
+  }, [filters, isAuthenticated])
+
   if (isLoading) {
     return <div className="min-h-screen bg-background flex items-center justify-center">Loading...</div>
   }
@@ -35,31 +61,6 @@ export default function AdminReportsPage() {
   if (!isAuthenticated) {
     return null
   }
-
-  const fetchReport = async () => {
-    try {
-      setReportLoading(true)
-      const params = new URLSearchParams()
-      if (filters.startDate) params.append("startDate", filters.startDate)
-      if (filters.endDate) params.append("endDate", filters.endDate)
-      if (filters.branchId) params.append("branchId", filters.branchId)
-
-      const res = await fetch(`/api/reports?${params.toString()}`)
-      const data = await res.json()
-      setSummary(data.summary)
-      setServiceStats(data.serviceStats || [])
-      setBranchStats(data.branchStats || [])
-    } catch (error) {
-      console.error("Failed to fetch report:", error)
-    } finally {
-      setReportLoading(false)
-    }
-  }
-
-  useEffect(() => {
-    fetchReport()
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [filters])
 
   return (
     <AdminLayout>


### PR DESCRIPTION
## Summary
- avoid conditional hook execution in admin reports page
- fetch reports only after authentication, preventing React error 310

## Testing
- `pnpm lint` *(fails: requires interactive ESLint config)*
- `pnpm build` *(fails: Failed to fetch font files from fonts.gstatic.com)*

------
https://chatgpt.com/codex/tasks/task_e_68bd007daedc832592013c535ea45122