### PR TITLE
refactor: streamline admin auth and reporting tools

### DIFF
--- a/app/admin/bookings/page.tsx
+++ b/app/admin/bookings/page.tsx
@@ -11,6 +11,7 @@ import { Plus } from "lucide-react"
 import Link from "next/link"
 import { apiClient } from "@/lib/api-client" // Import apiClient
 import { Booking, BookingApiResponse } from "@/lib/types" // Import Booking and BookingApiResponse types
+import { BookingExport } from "@/components/admin/booking-export"
 
 export default function AdminBookingsPage() {
   const [isAuthenticated, setIsAuthenticated] = useState(false)
@@ -24,9 +25,10 @@ export default function AdminBookingsPage() {
     if (authStatus === "true") {
       setIsAuthenticated(true)
       // Fetch bookings when authenticated
-      apiClient.getBookings() // Use apiClient.getBookings()
-        .then((data: BookingApiResponse) => { // Type the data parameter
-          setBookings(data.bookings); // Assuming the API returns data in the format { bookings: Booking[] }
+      apiClient
+        .getBookings({ limit: 1000 })
+        .then(({ bookings }: BookingApiResponse) => {
+          setBookings(bookings)
         })
         .catch((error: Error) => { // Type the error parameter
           console.error("Error fetching bookings:", error);
@@ -54,12 +56,15 @@ export default function AdminBookingsPage() {
             <h1 className="font-serif text-2xl md:text-3xl font-bold text-foreground">Kelola Booking</h1>
             <p className="text-muted-foreground mt-1">Kelola dan pantau semua booking pelanggan</p>
           </div>
-          <Button asChild>
-            <Link href="/admin/bookings/create" className="flex items-center gap-2">
-              <Plus className="w-4 h-4" />
-              Buat Booking Manual
-            </Link>
-          </Button>
+          <div className="flex items-center gap-2">
+            <BookingExport searchTerm={searchTerm} />
+            <Button asChild>
+              <Link href="/admin/bookings/create" className="flex items-center gap-2">
+                <Plus className="w-4 h-4" />
+                Buat Booking Manual
+              </Link>
+            </Button>
+          </div>
         </div>
 
         <BookingStats bookings={bookings} /> {/* Pass bookings to BookingStats */}

--- a/app/admin/bookings/page.tsx
+++ b/app/admin/bookings/page.tsx
@@ -16,6 +16,7 @@ export default function AdminBookingsPage() {
   const [isAuthenticated, setIsAuthenticated] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
   const [bookings, setBookings] = useState<Booking[]>([]) // State for bookings
+  const [searchTerm, setSearchTerm] = useState("")
   const router = useRouter()
 
   useEffect(() => {
@@ -62,8 +63,8 @@ export default function AdminBookingsPage() {
         </div>
 
         <BookingStats bookings={bookings} /> {/* Pass bookings to BookingStats */}
-        <BookingFilters />
-        <BookingList />
+        <BookingFilters onSearchChange={setSearchTerm} />
+        <BookingList searchTerm={searchTerm} />
       </div>
     </AdminLayout>
   )

--- a/app/admin/reports/page.tsx
+++ b/app/admin/reports/page.tsx
@@ -70,7 +70,7 @@ export default function AdminReportsPage() {
             <h1 className="font-serif text-2xl md:text-3xl font-bold text-foreground">Laporan & Analisis</h1>
             <p className="text-muted-foreground mt-1">Analisis performa bisnis dan laporan keuangan</p>
           </div>
-          <ReportExport />
+          <ReportExport filters={filters} />
         </div>
 
         <ReportFilters onChange={setFilters} />

--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -19,7 +19,6 @@ interface CreateBookingInput {
   notes?: string
   booking_source?: string
   created_by_admin?: boolean
-  admin_user_id?: string
 }
 
 function validateBookingInput(data: any): CreateBookingInput {

--- a/app/track/page.tsx
+++ b/app/track/page.tsx
@@ -11,7 +11,7 @@ import { Calendar, Car, CheckCircle, Clock, MapPin, Search, XCircle } from "luci
 import { format } from "date-fns"
 import { id } from "date-fns/locale"
 
-type BookingStatus = "pending" | "confirmed" | "in-progress" | "completed" | "cancelled"
+type BookingStatus = "pending" | "confirmed" | "picked-up" | "in-progress" | "completed" | "cancelled"
 
 export default function TrackBookingPage() {
   const [code, setCode] = useState("")
@@ -43,6 +43,8 @@ export default function TrackBookingPage() {
         return <Badge className="bg-blue-100 text-blue-800 hover:bg-blue-100">Dikonfirmasi</Badge>
       case "in-progress":
         return <Badge className="bg-purple-100 text-purple-800 hover:bg-purple-100">Berlangsung</Badge>
+      case "picked-up":
+        return <Badge className="bg-indigo-100 text-indigo-800 hover:bg-indigo-100">Dijemput</Badge>
       case "completed":
         return <Badge className="bg-green-100 text-green-800 hover:bg-green-100">Selesai</Badge>
       case "cancelled":
@@ -52,12 +54,15 @@ export default function TrackBookingPage() {
     }
   }
 
-  const steps: { key: BookingStatus; label: string; desc: string }[] = [
+  const baseSteps: { key: BookingStatus; label: string; desc: string }[] = [
     { key: "pending", label: "Menunggu Pembayaran/Konfirmasi", desc: "Booking dibuat" },
     { key: "confirmed", label: "Dikonfirmasi", desc: "Jadwal sudah dikonfirmasi" },
+    { key: "picked-up", label: "Dijemput", desc: "Kendaraan sedang dijemput" },
     { key: "in-progress", label: "Sedang Dikerjakan", desc: "Layanan sedang berlangsung" },
     { key: "completed", label: "Selesai", desc: "Layanan selesai" },
   ]
+
+  const steps = booking?.is_pickup_service ? baseSteps : baseSteps.filter((s) => s.key !== "picked-up")
 
   const stepIndex = (s: BookingStatus) => steps.findIndex((st) => st.key === s)
 

--- a/components/admin/booking-detail-modal.tsx
+++ b/components/admin/booking-detail-modal.tsx
@@ -43,7 +43,7 @@ interface BookingDetailModalProps {
     date: string
     time: string
     amount: number
-    status: "pending" | "confirmed" | "in-progress" | "completed" | "cancelled"
+    status: "pending" | "confirmed" | "picked-up" | "in-progress" | "completed" | "cancelled"
     createdAt: string
     updatedAt: string
     paymentMethod: string
@@ -76,6 +76,8 @@ export function BookingDetailModal({ booking, isOpen, onClose, onStatusChange }:
         return <Badge className="bg-yellow-100 text-yellow-800 hover:bg-yellow-100">Menunggu</Badge>
       case "in-progress":
         return <Badge className="bg-purple-100 text-purple-800 hover:bg-purple-100">Berlangsung</Badge>
+      case "picked-up":
+        return <Badge className="bg-indigo-100 text-indigo-800 hover:bg-indigo-100">Dijemput</Badge>
       case "completed":
         return <Badge className="bg-green-100 text-green-800 hover:bg-green-100">Selesai</Badge>
       case "cancelled":
@@ -85,7 +87,7 @@ export function BookingDetailModal({ booking, isOpen, onClose, onStatusChange }:
     }
   }
 
-  const getAvailableStatusOptions = (currentStatus: string) => {
+  const getAvailableStatusOptions = (currentStatus: string, isPickup: boolean) => {
     switch (currentStatus) {
       case "pending":
         return [
@@ -94,9 +96,13 @@ export function BookingDetailModal({ booking, isOpen, onClose, onStatusChange }:
         ]
       case "confirmed":
         return [
-          { value: "in-progress", label: "Mulai Layanan" },
+          ...(isPickup
+            ? [{ value: "picked-up", label: "Jemput" }]
+            : [{ value: "in-progress", label: "Mulai Layanan" }]),
           { value: "cancelled", label: "Batalkan" },
         ]
+      case "picked-up":
+        return [{ value: "in-progress", label: "Mulai Layanan" }]
       case "in-progress":
         return [{ value: "completed", label: "Selesaikan" }]
       default:
@@ -139,7 +145,7 @@ export function BookingDetailModal({ booking, isOpen, onClose, onStatusChange }:
     setShowReceipt(true)
   }
 
-  const statusOptions = getAvailableStatusOptions(booking.status)
+  const statusOptions = getAvailableStatusOptions(booking.status, booking.isPickupService || false)
 
   if (showReceipt) {
     const receiptData = {

--- a/components/admin/booking-export.tsx
+++ b/components/admin/booking-export.tsx
@@ -1,0 +1,103 @@
+"use client"
+
+import { useState } from "react"
+import { Button } from "@/components/ui/button"
+import { Download, FileSpreadsheet, FileText, Printer } from "lucide-react"
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu"
+import jsPDF from "jspdf"
+
+interface BookingExportProps {
+  searchTerm?: string
+}
+
+export function BookingExport({ searchTerm }: BookingExportProps) {
+  const [isExporting, setIsExporting] = useState(false)
+
+  const fetchBookings = async () => {
+    const params = new URLSearchParams()
+    if (searchTerm) params.append("search", searchTerm)
+    params.append("limit", "1000")
+    const res = await fetch(`/api/bookings?${params.toString()}`)
+    return res.json()
+  }
+
+  const exportCSV = (data: any) => {
+    const rows = [
+      ["Kode", "Nama", "Telepon", "Layanan", "Cabang", "Tanggal", "Waktu", "Total", "Status"],
+      ...data.bookings.map((b: any) => [
+        b.booking_code,
+        b.customer_name,
+        b.customer_phone,
+        b.services?.name || "",
+        b.branches?.name || "",
+        b.booking_date,
+        b.booking_time,
+        b.total_price,
+        b.status,
+      ]),
+    ]
+
+    const csvContent = rows.map((r) => r.join(",")).join("\n")
+    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement("a")
+    link.href = url
+    link.download = `bookings-${Date.now()}.csv`
+    link.click()
+    URL.revokeObjectURL(url)
+  }
+
+  const handleExport = async (format: string) => {
+    setIsExporting(true)
+    try {
+      const data = await fetchBookings()
+      if (format === "excel") {
+        exportCSV(data)
+      } else if (format === "pdf") {
+        const doc = new jsPDF()
+        doc.text("Daftar Booking", 10, 10)
+        data.bookings.forEach((b: any, i: number) => {
+          doc.text(
+            `${i + 1}. ${b.booking_code} - ${b.customer_name} - ${b.status}`,
+            10,
+            20 + i * 10,
+          )
+        })
+        doc.save(`bookings-${Date.now()}.pdf`)
+      }
+    } catch (err) {
+      console.error("Failed to export bookings", err)
+    } finally {
+      setIsExporting(false)
+    }
+  }
+
+  const handlePrint = () => {
+    window.print()
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button disabled={isExporting} className="flex items-center gap-2">
+          <Download className="w-4 h-4" />
+          {isExporting ? "Mengekspor..." : "Ekspor"}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>Format Ekspor</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={() => handleExport("pdf")}>
+          <FileText className="mr-2 h-4 w-4" /> PDF
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => handleExport("excel")}>
+          <FileSpreadsheet className="mr-2 h-4 w-4" /> Excel
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={handlePrint}>
+          <Printer className="mr-2 h-4 w-4" /> Cetak
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}

--- a/components/admin/booking-filters.tsx
+++ b/components/admin/booking-filters.tsx
@@ -80,6 +80,7 @@ export function BookingFilters({ onSearchChange }: { onSearchChange?: (term: str
                     <SelectItem value="all">Semua Status</SelectItem>
                     <SelectItem value="pending">Menunggu</SelectItem>
                     <SelectItem value="confirmed">Dikonfirmasi</SelectItem>
+                    <SelectItem value="picked-up">Dijemput</SelectItem>
                     <SelectItem value="in-progress">Berlangsung</SelectItem>
                     <SelectItem value="completed">Selesai</SelectItem>
                     <SelectItem value="cancelled">Dibatalkan</SelectItem>

--- a/components/admin/booking-filters.tsx
+++ b/components/admin/booking-filters.tsx
@@ -13,7 +13,7 @@ import { format } from "date-fns"
 import { id } from "date-fns/locale"
 import { cn } from "@/lib/utils"
 
-export function BookingFilters() {
+export function BookingFilters({ onSearchChange }: { onSearchChange?: (term: string) => void }) {
   const [searchTerm, setSearchTerm] = useState("")
   const [statusFilter, setStatusFilter] = useState("all")
   const [branchFilter, setBranchFilter] = useState("all")
@@ -42,7 +42,10 @@ export function BookingFilters() {
               <Input
                 placeholder="Cari berdasarkan nama, kode booking, atau telepon..."
                 value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
+                onChange={(e) => {
+                  setSearchTerm(e.target.value)
+                  onSearchChange?.(e.target.value)
+                }}
                 className="pl-10"
               />
             </div>

--- a/components/admin/booking-list.tsx
+++ b/components/admin/booking-list.tsx
@@ -14,12 +14,12 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
 import { BookingDetailModal } from "@/components/admin/booking-detail-modal"
-import { MoreHorizontal, Eye, CheckCircle, XCircle, Clock, Phone, FileImage } from "lucide-react"
+import { MoreHorizontal, Eye, CheckCircle, XCircle, Clock, Phone, FileImage, Car } from "lucide-react"
 import { format } from "date-fns"
 import { id } from "date-fns/locale"
 import { apiClient } from "@/lib/api-client"
 import { sendWhatsAppNotification } from "@/lib/whatsapp-utils"
-import type { Booking, Service, Branch } from "@/lib/dummy-data"
+import type { Booking } from "@/lib/dummy-data"
 import { ErrorState } from "@/components/ui/error-state"
 import { showErrorToast, showSuccessToast } from "@/lib/error-utils"
 
@@ -39,7 +39,8 @@ interface BookingWithDetails extends Booking {
   customerPhone: string;
   customerEmail: string;
   totalPrice: number;
-  status: "pending" | "confirmed" | "in-progress" | "completed" | "cancelled";
+  status: "pending" | "confirmed" | "picked-up" | "in-progress" | "completed" | "cancelled";
+  isPickupService: boolean;
 
   // Derived properties for display in the table and for the modal
   service: string; // Service name as string (non-nullable)
@@ -60,64 +61,61 @@ export function BookingList({ searchTerm = "" }: { searchTerm?: string }) {
   const [selectedBooking, setSelectedBooking] = useState<BookingWithDetails | null>(null)
   const [isDetailModalOpen, setIsDetailModalOpen] = useState(false)
   const [updatingStatus, setUpdatingStatus] = useState<string | null>(null)
+  const [total, setTotal] = useState(0)
+  const [page, setPage] = useState(1)
+  const pageSize = 10
 
-  const filteredBookings = bookings.filter((booking) => {
-    const term = searchTerm.toLowerCase()
-    return (
-      booking.customerName.toLowerCase().includes(term) ||
-      booking.customerPhone.includes(term) ||
-      booking.bookingCode.toLowerCase().includes(term)
-    )
-  })
+  useEffect(() => {
+    setPage(1)
+  }, [searchTerm])
 
   useEffect(() => {
     fetchBookings()
-  }, [])
+  }, [page, searchTerm])
 
   const fetchBookings = async () => {
     try {
       setLoading(true)
       setError(null)
-
-      const { bookings: bookingsData } = await apiClient.getBookings()
-      const { services } = await apiClient.getServices()
-      const { branches } = await apiClient.getBranches()
+      const { bookings: bookingsData, total } = await apiClient.getBookings({
+        page,
+        limit: pageSize,
+        search: searchTerm,
+      })
 
       const enrichedBookings: BookingWithDetails[] = bookingsData.map((booking) => ({
-        // Explicitly map all properties required by BookingWithDetails
         id: booking.id,
         serviceId: booking.service_id,
         branchId: booking.branch_id,
-        date: booking.booking_date, // Assuming booking.date exists
-        time: booking.booking_time, // Assuming booking.time exists
-        // Handle bookingSource type mismatch - provide a default if unknown
-        bookingSource: booking.booking_source === "online" || booking.booking_source === "offline" ? booking.booking_source : "offline", // Default to offline if unknown
+        date: booking.booking_date,
+        time: booking.booking_time,
+        bookingSource:
+          booking.booking_source === "online" || booking.booking_source === "offline"
+            ? booking.booking_source
+            : "offline",
         vehiclePlateNumber: booking.vehicle_plate_number,
         createdAt: booking.created_at,
         updatedAt: booking.updated_at,
-        loyaltyPointsEarned: booking.loyalty_points_earned, // Use corrected name
+        loyaltyPointsEarned: booking.loyalty_points_earned,
         bookingCode: booking.booking_code,
         customerName: booking.customer_name,
         customerPhone: booking.customer_phone,
         customerEmail: booking.customer_email,
         totalPrice: booking.total_price,
         status: booking.status,
+        isPickupService: booking.is_pickup_service,
 
-        // Derived properties
-        service: services.find((s) => s.id === booking.service_id)?.name || "Layanan tidak ditemukan", // Ensure non-nullable string
-        branch: branches.find((b) => b.id === booking.branch_id)?.name || "Cabang tidak ditemukan", // Ensure non-nullable string
+        service: booking.services?.name || "Layanan tidak ditemukan",
+        branch: booking.branches?.name || "Cabang tidak ditemukan",
         amount: booking.total_price,
-        paymentProof: (booking as any).payment_proof || null,
-        branchAddress: booking.branches?.address ||
-          branches.find((b) => b.id === booking.branch_id)?.address || "",
-        branchPhone: booking.branches?.phone ||
-          branches.find((b) => b.id === booking.branch_id)?.phone || "",
+        paymentProof: booking.payment_proof || null,
+        branchAddress: booking.branches?.address || "",
+        branchPhone: booking.branches?.phone || "",
         paymentMethod: booking.payment_method,
       }))
 
-      enrichedBookings.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
-
       setBookings(enrichedBookings)
+      setTotal(total)
     } catch (err) {
       console.error("[v0] Error fetching bookings:", err)
       setError("Gagal memuat data booking")
@@ -143,6 +141,8 @@ export function BookingList({ searchTerm = "" }: { searchTerm?: string }) {
         return <Badge className="bg-yellow-100 text-yellow-800 hover:bg-yellow-100">Menunggu</Badge>
       case "in-progress":
         return <Badge className="bg-purple-100 text-purple-800 hover:bg-purple-100">Berlangsung</Badge>
+      case "picked-up":
+        return <Badge className="bg-indigo-100 text-indigo-800 hover:bg-indigo-100">Dijemput</Badge>
       case "completed":
         return <Badge className="bg-green-100 text-green-800 hover:bg-green-100">Selesai</Badge>
       case "cancelled":
@@ -232,14 +232,14 @@ export function BookingList({ searchTerm = "" }: { searchTerm?: string }) {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {filteredBookings.length === 0 ? (
+                {bookings.length === 0 ? (
                   <TableRow>
                     <TableCell colSpan={8} className="text-center py-8 text-muted-foreground">
                       Belum ada booking yang tersedia
                     </TableCell>
                   </TableRow>
                 ) : (
-                  filteredBookings.map((booking) => (
+                  bookings.map((booking) => (
                     <TableRow key={booking.id}>
                       <TableCell className="font-medium font-mono">
                         <div className="flex items-center gap-2">
@@ -315,19 +315,31 @@ export function BookingList({ searchTerm = "" }: { searchTerm?: string }) {
                                   Konfirmasi
                                 </DropdownMenuItem>
                               )}
-                              {booking.status === "confirmed" && (
-                                <DropdownMenuItem onClick={() => handleStatusChange(booking.id, "in-progress")}>
-                                  <Clock className="mr-2 h-4 w-4" />
-                                  Mulai Layanan
-                                </DropdownMenuItem>
+                              {booking.status === "confirmed" && booking.isPickupService && (
+                                <DropdownMenuItem onClick={() => handleStatusChange(booking.id, "picked-up")}> 
+                                  <Car className="mr-2 h-4 w-4" /> 
+                                  Jemput 
+                                </DropdownMenuItem> 
+                              )}
+                              {booking.status === "confirmed" && !booking.isPickupService && (
+                                <DropdownMenuItem onClick={() => handleStatusChange(booking.id, "in-progress")}> 
+                                  <Clock className="mr-2 h-4 w-4" /> 
+                                  Mulai Layanan 
+                                </DropdownMenuItem> 
+                              )}
+                              {booking.status === "picked-up" && (
+                                <DropdownMenuItem onClick={() => handleStatusChange(booking.id, "in-progress")}> 
+                                  <Clock className="mr-2 h-4 w-4" /> 
+                                  Mulai Layanan 
+                                </DropdownMenuItem> 
                               )}
                               {booking.status === "in-progress" && (
-                                <DropdownMenuItem onClick={() => handleStatusChange(booking.id, "completed")}>
-                                  <CheckCircle className="mr-2 h-4 w-4" />
-                                  Selesaikan
-                                </DropdownMenuItem>
+                                <DropdownMenuItem onClick={() => handleStatusChange(booking.id, "completed")}> 
+                                  <CheckCircle className="mr-2 h-4 w-4" /> 
+                                  Selesaikan 
+                                </DropdownMenuItem> 
                               )}
-                              {(booking.status === "pending" || booking.status === "confirmed") && (
+                              {(booking.status === "pending" || booking.status === "confirmed" || booking.status === "picked-up") && (
                                 <DropdownMenuItem
                                   onClick={() => handleStatusChange(booking.id, "cancelled")}
                                   className="text-red-600"
@@ -345,6 +357,33 @@ export function BookingList({ searchTerm = "" }: { searchTerm?: string }) {
                 )}
               </TableBody>
             </Table>
+          </div>
+          <div className="flex items-center justify-between py-4">
+            <div className="text-sm text-muted-foreground">
+              Menampilkan {bookings.length ? (page - 1) * pageSize + 1 : 0}-
+              {(page - 1) * pageSize + bookings.length} dari {total} booking
+            </div>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage(page - 1)}
+                disabled={page === 1}
+              >
+                Sebelumnya
+              </Button>
+              <span className="text-sm">
+                Halaman {page} dari {Math.ceil(total / pageSize) || 1}
+              </span>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setPage(page + 1)}
+                disabled={page >= Math.ceil(total / pageSize)}
+              >
+                Selanjutnya
+              </Button>
+            </div>
           </div>
         </CardContent>
       </Card>

--- a/components/admin/booking-list.tsx
+++ b/components/admin/booking-list.tsx
@@ -51,16 +51,24 @@ interface BookingWithDetails extends Booking {
   branchAddress: string;
   branchPhone: string;
   paymentMethod: string;
-  staff?: string;
 }
 
-export function BookingList() {
+export function BookingList({ searchTerm = "" }: { searchTerm?: string }) {
   const [bookings, setBookings] = useState<BookingWithDetails[]>([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [selectedBooking, setSelectedBooking] = useState<BookingWithDetails | null>(null)
   const [isDetailModalOpen, setIsDetailModalOpen] = useState(false)
   const [updatingStatus, setUpdatingStatus] = useState<string | null>(null)
+
+  const filteredBookings = bookings.filter((booking) => {
+    const term = searchTerm.toLowerCase()
+    return (
+      booking.customerName.toLowerCase().includes(term) ||
+      booking.customerPhone.includes(term) ||
+      booking.bookingCode.toLowerCase().includes(term)
+    )
+  })
 
   useEffect(() => {
     fetchBookings()
@@ -105,7 +113,6 @@ export function BookingList() {
         branchPhone: booking.branches?.phone ||
           branches.find((b) => b.id === booking.branch_id)?.phone || "",
         paymentMethod: booking.payment_method,
-        staff: booking.admin_user_id || undefined,
       }))
 
       enrichedBookings.sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
@@ -225,14 +232,14 @@ export function BookingList() {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {bookings.length === 0 ? (
+                {filteredBookings.length === 0 ? (
                   <TableRow>
                     <TableCell colSpan={8} className="text-center py-8 text-muted-foreground">
                       Belum ada booking yang tersedia
                     </TableCell>
                   </TableRow>
                 ) : (
-                  bookings.map((booking) => (
+                  filteredBookings.map((booking) => (
                     <TableRow key={booking.id}>
                       <TableCell className="font-medium font-mono">
                         <div className="flex items-center gap-2">

--- a/components/admin/booking-stats.tsx
+++ b/components/admin/booking-stats.tsx
@@ -13,7 +13,7 @@ export function BookingStats({ bookings }: BookingStatsProps) {
     (booking) => booking.status === "confirmed"
   ).length;
   const inProgressBookings = bookings.filter(
-    (booking) => booking.status === "in-progress"
+    (booking) => booking.status === "in-progress" || booking.status === "picked-up"
   ).length;
   const completedBookings = bookings.filter(
     (booking) => booking.status === "completed"

--- a/components/admin/notification-templates.tsx
+++ b/components/admin/notification-templates.tsx
@@ -6,7 +6,7 @@ import { Label } from "@/components/ui/label"
 import { Textarea } from "@/components/ui/textarea"
 import { Button } from "@/components/ui/button"
 
-type StatusKey = "pending" | "confirmed" | "in-progress" | "completed" | "cancelled"
+type StatusKey = "pending" | "confirmed" | "picked-up" | "in-progress" | "completed" | "cancelled"
 
 const defaultTemplates: Record<StatusKey, string> = {
   pending:
@@ -15,6 +15,8 @@ const defaultTemplates: Record<StatusKey, string> = {
     "Halo {customerName},\n\nBooking Anda sudah dikonfirmasi.\n📌 Kode: {bookingCode}\n🛠 Layanan: {service}\n📅 Jadwal: {date} {time}\n🏢 Cabang: {branch}\n\nSampai jumpa tepat waktu!",
   "in-progress":
     "Halo {customerName},\n\nKendaraan Anda sedang dalam proses pengerjaan.\n📌 Kode: {bookingCode}\n🛠 Layanan: {service}",
+  "picked-up":
+    "Halo {customerName},\n\nKendaraan Anda sedang dijemput oleh tim kami.\n📌 Kode: {bookingCode}\n🛠 Layanan: {service}",
   completed:
     "Halo {customerName},\n\nLayanan telah selesai. Terima kasih!\n📌 Kode: {bookingCode}\n🛠 Layanan: {service}",
   cancelled:

--- a/components/admin/recent-bookings.tsx
+++ b/components/admin/recent-bookings.tsx
@@ -70,6 +70,8 @@ export function RecentBookings() {
         return <Badge className="bg-yellow-100 text-yellow-800 hover:bg-yellow-100">Menunggu</Badge>
       case "in-progress":
         return <Badge className="bg-purple-100 text-purple-800 hover:bg-purple-100">Berlangsung</Badge>
+      case "picked-up":
+        return <Badge className="bg-indigo-100 text-indigo-800 hover:bg-indigo-100">Dijemput</Badge>
       case "completed":
         return <Badge className="bg-green-100 text-green-800 hover:bg-green-100">Selesai</Badge>
       case "cancelled":

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -37,7 +37,6 @@ interface Booking {
   notes?: string
   booking_source: string
   created_by_admin: boolean
-  admin_user_id: string | null;
   created_at: string
   updated_at: string
   services: {
@@ -121,7 +120,6 @@ interface CreateBookingData {
   notes?: string
   booking_source?: string
   created_by_admin?: boolean
-  admin_user_id?: string
 }
 
 class ApiClient {

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -25,7 +25,7 @@ interface Booking {
   booking_date: string // ISO date string
   booking_time: string // HH:MM format
   total_price: number
-  status: "pending" | "confirmed" | "in-progress" | "completed" | "cancelled"
+  status: "pending" | "confirmed" | "picked-up" | "in-progress" | "completed" | "cancelled"
   is_pickup_service: boolean
   pickup_address: string | null;
   pickup_notes: string | null;
@@ -202,16 +202,22 @@ class ApiClient {
     status?: string
     date?: string
     limit?: number
-  }): Promise<{ bookings: Booking[] }> {
+    page?: number
+    search?: string
+  }): Promise<{ bookings: Booking[]; total: number }> {
     try {
       const searchParams = new URLSearchParams()
       if (params?.branchId) searchParams.set("branchId", params.branchId)
       if (params?.status) searchParams.set("status", params.status)
       if (params?.date) searchParams.set("date", params.date)
       if (params?.limit) searchParams.set("limit", params.limit.toString())
+      if (params?.page) searchParams.set("page", params.page.toString())
+      if (params?.search) searchParams.set("search", params.search)
 
       const query = searchParams.toString()
-      const result = await this.request<{ bookings: Booking[] }>(`/bookings${query ? `?${query}` : ""}`)
+      const result = await this.request<{ bookings: Booking[]; total: number }>(
+        `/bookings${query ? `?${query}` : ""}`,
+      )
 
       return result
     } catch (error) {

--- a/lib/dummy-data.ts
+++ b/lib/dummy-data.ts
@@ -43,7 +43,7 @@ export interface Booking {
   date: string
   time: string
   totalPrice: number
-  status: "pending" | "confirmed" | "in-progress" | "completed" | "cancelled"
+  status: "pending" | "confirmed" | "picked-up" | "in-progress" | "completed" | "cancelled"
   paymentProof?: string
   createdAt: string
   updatedAt: string

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -20,7 +20,6 @@ export interface Booking {
   loyalty_points_used: number;
   booking_source: string;
   created_by_admin: boolean;
-  admin_user_id: string | null;
   payment_method: string;
   notes: string | null;
   created_at: string;

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -10,7 +10,7 @@ export interface Booking {
   booking_date: string;
   booking_time: string;
   total_price: number;
-  status: "confirmed" | "in-progress" | "completed" | "cancelled" | "pending"; // Added "pending" status
+  status: "confirmed" | "picked-up" | "in-progress" | "completed" | "cancelled" | "pending"; // Added "pending" status
   payment_proof: string | null;
   is_pickup_service: boolean;
   pickup_address: string | null;
@@ -41,6 +41,7 @@ export interface Booking {
 // Define the structure for the API response
 export interface BookingApiResponse {
   bookings: Booking[];
+  total?: number;
 }
 
 // Define the structure for booking statistics

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -269,8 +269,8 @@ export const handleApiError = (error: unknown): string => {
 // Type Guards
 export const isValidBookingStatus = (
   status: string,
-): status is "pending" | "confirmed" | "in-progress" | "completed" | "cancelled" => {
-  return ["pending", "confirmed", "in-progress", "completed", "cancelled"].includes(status)
+): status is "pending" | "confirmed" | "picked-up" | "in-progress" | "completed" | "cancelled" => {
+  return ["pending", "confirmed", "picked-up", "in-progress", "completed", "cancelled"].includes(status)
 }
 
 export const isValidPaymentMethod = (method: string): method is "cash" | "transfer" | "qris" | "card" => {

--- a/lib/whatsapp-utils.ts
+++ b/lib/whatsapp-utils.ts
@@ -42,13 +42,16 @@ const generateWhatsAppMessage = (booking: BookingWithDetails): string => {
         confirmed: `Booking Anda sudah *Terkonfirmasi*. ✅  
     Mohon datang ke cabang sesuai jadwal yang dipilih. Terima kasih! 🙌`,
 
-        "in-progress": `Booking Anda sedang dalam proses *Pengerjaan*. 🧽  
+        "in-progress": `Booking Anda sedang dalam proses *Pengerjaan*. 🧽
     Tim kami saat ini sedang membersihkan kendaraan Anda.`,
+
+        "picked-up": `Booking Anda sedang dalam proses *Penjemputan*. 🚗
+    Tim kami sedang menuju lokasi Anda.`,
 
         completed: `Proses pembersihan kendaraan Anda sudah *Selesai*! 🎉  
     Terima kasih telah mempercayakan layanan kami. Semoga puas dan sampai jumpa lagi! 🙏`,
 
-        cancelled: `Mohon maaf, booking Anda telah *Dibatalkan*. ❌  
+        cancelled: `Mohon maaf, booking Anda telah *Dibatalkan*. ❌
     Jika pembatalan ini tidak sesuai, silakan hubungi admin kami untuk bantuan lebih lanjut.`,
     }
 

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "geist": "^1.3.1",
     "input-otp": "1.4.1",
     "jsonwebtoken": "latest",
+    "jspdf": "^3.0.2",
     "lucide-react": "^0.454.0",
     "next": "15.2.4",
     "next-themes": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       jsonwebtoken:
         specifier: latest
         version: 9.0.2
+      jspdf:
+        specifier: ^3.0.2
+        version: 3.0.2
       lucide-react:
         specifier: ^0.454.0
         version: 0.454.0(react@19.0.0)
@@ -229,6 +232,10 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@babel/runtime@7.28.4':
+    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
+    engines: {node: '>=6.9.0'}
 
   '@date-fns/tz@1.2.0':
     resolution: {integrity: sha512-LBrd7MiJZ9McsOgxqWX7AaxrDjcFVjWH/tIKJd7pnR7McaslGYOP1QmmiBXdJH/H/yLCT+rcQ7FaPBUxRGUtrg==}
@@ -1588,14 +1595,23 @@ packages:
   '@types/node@22.0.0':
     resolution: {integrity: sha512-VT7KSYudcPOzP5Q0wfbowyNLaVR8QWUdw+088uFWwfvpY6uCWaXpqV6ieLAu9WBcnTa7H4Z5RLK8I5t2FuOcqw==}
 
+  '@types/pako@2.0.4':
+    resolution: {integrity: sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==}
+
   '@types/phoenix@1.6.6':
     resolution: {integrity: sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==}
+
+  '@types/raf@3.4.3':
+    resolution: {integrity: sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==}
 
   '@types/react-dom@19.0.0':
     resolution: {integrity: sha512-1KfiQKsH1o00p9m5ag12axHQSb3FOU9H20UTrujVSkNhuCrRHiQWFqgEnTNK5ZNfnzZv8UWrnXVqCmCF9fgY3w==}
 
   '@types/react@19.0.0':
     resolution: {integrity: sha512-MY3oPudxvMYyesqs/kW1Bh8y9VqSmf+tzqw3ae8a9DZW68pUe3zAdHeI1jc6iAysuRdACnVknHP8AhwD4/dxtg==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
@@ -1846,6 +1862,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
+
   bcryptjs@3.0.2:
     resolution: {integrity: sha512-k38b3XOZKv60C4E2hVsXTolJWfkGRMbILBIe2IBITXciy5bOsTKot5kDrf3ZfufQtQOUN5mXceUEpU1rTl9Uog==}
     hasBin: true
@@ -1890,6 +1910,10 @@ packages:
 
   caniuse-lite@1.0.30001735:
     resolution: {integrity: sha512-EV/laoX7Wq2J9TQlyIXRxTJqIw4sxfXS4OYgudGxBYRuTv0q7AM6yMEpU/Vo1I94thg9U6EZ2NfZx9GJq83u7w==}
+
+  canvg@3.0.11:
+    resolution: {integrity: sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==}
+    engines: {node: '>=10.0.0'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1936,9 +1960,15 @@ packages:
     resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
     engines: {node: '>=18'}
 
+  core-js@3.45.1:
+    resolution: {integrity: sha512-L4NPsJlCfZsPeXukyzHFlg/i7IIVwHSItR0wg0FLNqYClJ4MQYTYLbC7EkjKYRLZF2iof2MUgN0EGy7MdQFChg==}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-line-break@2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
@@ -2049,6 +2079,9 @@ packages:
   doctrine@2.1.0:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
+
+  dompurify@3.2.6:
+    resolution: {integrity: sha512-/2GogDQlohXPZe6D6NOgQvXLPSYBqIWMnZ8zzOhn09REE4eyAzb+Hed3jhoM9OkuaJ8P6ZGTTVWQKAi8ieIzfQ==}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -2265,6 +2298,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-png@6.4.0:
+    resolution: {integrity: sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==}
+
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
 
@@ -2276,6 +2312,9 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fflate@0.8.2:
+    resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
@@ -2390,6 +2429,10 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  html2canvas@1.4.1:
+    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
+    engines: {node: '>=8.0.0'}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -2422,6 +2465,9 @@ packages:
   internmap@2.0.3:
     resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
     engines: {node: '>=12'}
+
+  iobuffer@5.4.0:
+    resolution: {integrity: sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -2566,6 +2612,9 @@ packages:
   jsonwebtoken@9.0.2:
     resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
     engines: {node: '>=12', npm: '>=6'}
+
+  jspdf@3.0.2:
+    resolution: {integrity: sha512-G0fQDJ5fAm6UW78HG6lNXyq09l0PrA1rpNY5i+ly17Zb1fMMFSmS+3lw4cnrAPGyouv2Y0ylujbY2Ieq3DSlKA==}
 
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
@@ -2828,6 +2877,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  pako@2.1.0:
+    resolution: {integrity: sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -2842,6 +2894,9 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  performance-now@2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2887,6 +2942,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  raf@3.4.1:
+    resolution: {integrity: sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==}
 
   react-day-picker@9.8.1:
     resolution: {integrity: sha512-kMcLrp3PfN/asVJayVv82IjF3iLOOxuH5TNFWezX6lS/T8iVRFPTETpHl3TUSTH99IDMZLubdNPJr++rQctkEw==}
@@ -2983,6 +3041,9 @@ packages:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
 
+  regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
@@ -3009,6 +3070,10 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rgbcolor@1.0.1:
+    resolution: {integrity: sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==}
+    engines: {node: '>= 0.8.15'}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -3096,6 +3161,10 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  stackblur-canvas@2.7.0:
+    resolution: {integrity: sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==}
+    engines: {node: '>=0.1.14'}
+
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
@@ -3156,6 +3225,10 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svg-pathdata@6.0.3:
+    resolution: {integrity: sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==}
+    engines: {node: '>=12.0.0'}
+
   tailwind-merge@2.5.5:
     resolution: {integrity: sha512-0LXunzzAZzo0tEPxV3I297ffKZPlKDrjj7NXphC8V5ak9yHC5zRmxnOe2m/Rd/7ivsOMJe3JZ2JVocoDdQTRBA==}
 
@@ -3174,6 +3247,9 @@ packages:
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+
+  text-segmentation@1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
 
   tiny-invariant@1.3.3:
     resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
@@ -3273,6 +3349,9 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  utrie@1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
+
   vaul@0.9.9:
     resolution: {integrity: sha512-7afKg48srluhZwIkaU+lgGtFCUsYBSGOl8vcc8N/M3YQlZFlynHD15AE+pwrYdc826o7nrIND4lL9Y6b9WWZZQ==}
     peerDependencies:
@@ -3344,6 +3423,8 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.30
+
+  '@babel/runtime@7.28.4': {}
 
   '@date-fns/tz@1.2.0': {}
 
@@ -4672,7 +4753,12 @@ snapshots:
     dependencies:
       undici-types: 6.11.1
 
+  '@types/pako@2.0.4': {}
+
   '@types/phoenix@1.6.6': {}
+
+  '@types/raf@3.4.3':
+    optional: true
 
   '@types/react-dom@19.0.0':
     dependencies:
@@ -4681,6 +4767,9 @@ snapshots:
   '@types/react@19.0.0':
     dependencies:
       csstype: 3.1.3
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/use-sync-external-store@0.0.6': {}
 
@@ -4956,6 +5045,9 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  base64-arraybuffer@1.0.2:
+    optional: true
+
   bcryptjs@3.0.2: {}
 
   brace-expansion@1.1.12:
@@ -5004,6 +5096,18 @@ snapshots:
   callsites@3.1.0: {}
 
   caniuse-lite@1.0.30001735: {}
+
+  canvg@3.0.11:
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@types/raf': 3.4.3
+      core-js: 3.45.1
+      raf: 3.4.1
+      regenerator-runtime: 0.13.11
+      rgbcolor: 1.0.1
+      stackblur-canvas: 2.7.0
+      svg-pathdata: 6.0.3
+    optional: true
 
   chalk@4.1.2:
     dependencies:
@@ -5054,11 +5158,19 @@ snapshots:
 
   cookie@1.0.2: {}
 
+  core-js@3.45.1:
+    optional: true
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-line-break@2.1.0:
+    dependencies:
+      utrie: 1.0.2
+    optional: true
 
   csstype@3.1.3: {}
 
@@ -5155,6 +5267,11 @@ snapshots:
   doctrine@2.1.0:
     dependencies:
       esutils: 2.0.3
+
+  dompurify@3.2.6:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+    optional: true
 
   dunder-proto@1.0.1:
     dependencies:
@@ -5519,6 +5636,12 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-png@6.4.0:
+    dependencies:
+      '@types/pako': 2.0.4
+      iobuffer: 5.4.0
+      pako: 2.1.0
+
   fastq@1.19.1:
     dependencies:
       reusify: 1.1.0
@@ -5526,6 +5649,8 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
+
+  fflate@0.8.2: {}
 
   file-entry-cache@8.0.0:
     dependencies:
@@ -5643,6 +5768,12 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  html2canvas@1.4.1:
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
+    optional: true
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
@@ -5668,6 +5799,8 @@ snapshots:
       side-channel: 1.1.0
 
   internmap@2.0.3: {}
+
+  iobuffer@5.4.0: {}
 
   is-array-buffer@3.0.5:
     dependencies:
@@ -5826,6 +5959,17 @@ snapshots:
       lodash.once: 4.1.1
       ms: 2.1.3
       semver: 7.7.2
+
+  jspdf@3.0.2:
+    dependencies:
+      '@babel/runtime': 7.28.4
+      fast-png: 6.4.0
+      fflate: 0.8.2
+    optionalDependencies:
+      canvg: 3.0.11
+      core-js: 3.45.1
+      dompurify: 3.2.6
+      html2canvas: 1.4.1
 
   jsx-ast-utils@3.3.5:
     dependencies:
@@ -6071,6 +6215,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  pako@2.1.0: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -6080,6 +6226,9 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  performance-now@2.1.0:
+    optional: true
 
   picocolors@1.1.1: {}
 
@@ -6116,6 +6265,11 @@ snapshots:
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  raf@3.4.1:
+    dependencies:
+      performance-now: 2.1.0
+    optional: true
 
   react-day-picker@9.8.1(react@19.0.0):
     dependencies:
@@ -6217,6 +6371,9 @@ snapshots:
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
 
+  regenerator-runtime@0.13.11:
+    optional: true
+
   regexp.prototype.flags@1.5.4:
     dependencies:
       call-bind: 1.0.8
@@ -6245,6 +6402,9 @@ snapshots:
       supports-preserve-symlinks-flag: 1.0.0
 
   reusify@1.1.0: {}
+
+  rgbcolor@1.0.1:
+    optional: true
 
   run-parallel@1.2.0:
     dependencies:
@@ -6374,6 +6534,9 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  stackblur-canvas@2.7.0:
+    optional: true
+
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
@@ -6446,6 +6609,9 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  svg-pathdata@6.0.3:
+    optional: true
+
   tailwind-merge@2.5.5: {}
 
   tailwindcss-animate@1.0.7(tailwindcss@4.1.9):
@@ -6464,6 +6630,11 @@ snapshots:
       minizlib: 3.0.2
       mkdirp: 3.0.1
       yallist: 5.0.0
+
+  text-segmentation@1.0.3:
+    dependencies:
+      utrie: 1.0.2
+    optional: true
 
   tiny-invariant@1.3.3: {}
 
@@ -6593,6 +6764,11 @@ snapshots:
   use-sync-external-store@1.5.0(react@19.0.0):
     dependencies:
       react: 19.0.0
+
+  utrie@1.0.2:
+    dependencies:
+      base64-arraybuffer: 1.0.2
+    optional: true
 
   vaul@0.9.9(@types/react-dom@19.0.0)(@types/react@19.0.0)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:

--- a/scripts/01-create-tables.sql
+++ b/scripts/01-create-tables.sql
@@ -47,22 +47,6 @@ CREATE TABLE IF NOT EXISTS customers (
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
   updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
 );
-
--- Create admins table
-CREATE TABLE IF NOT EXISTS admins (
-  id TEXT PRIMARY KEY,
-  username TEXT UNIQUE NOT NULL,
-  name TEXT NOT NULL,
-  email TEXT UNIQUE NOT NULL,
-  password_hash TEXT NOT NULL,
-  role TEXT NOT NULL CHECK (role IN ('super-admin', 'branch-admin', 'staff')),
-  branch_id TEXT REFERENCES branches(id),
-  is_active BOOLEAN DEFAULT true,
-  last_login TIMESTAMP WITH TIME ZONE,
-  created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-  updated_at TIMESTAMP WITH TIME ZONE DEFAULT NOW()
-);
-
 -- Create bookings table
 CREATE TABLE IF NOT EXISTS bookings (
   id TEXT PRIMARY KEY,
@@ -85,7 +69,6 @@ CREATE TABLE IF NOT EXISTS bookings (
   loyalty_points_used INTEGER DEFAULT 0,
   booking_source TEXT NOT NULL DEFAULT 'online' CHECK (booking_source IN ('online', 'offline')),
   created_by_admin BOOLEAN DEFAULT false,
-  admin_user_id TEXT REFERENCES admins(id),
   payment_method TEXT CHECK (payment_method IN ('cash', 'transfer', 'qris', 'card')),
   notes TEXT,
   created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
@@ -98,7 +81,6 @@ CREATE INDEX IF NOT EXISTS idx_bookings_status ON bookings(status);
 CREATE INDEX IF NOT EXISTS idx_bookings_branch ON bookings(branch_id);
 CREATE INDEX IF NOT EXISTS idx_bookings_customer_phone ON bookings(customer_phone);
 CREATE INDEX IF NOT EXISTS idx_customers_phone ON customers(phone);
-CREATE INDEX IF NOT EXISTS idx_admins_username ON admins(username);
 
 -- Record each change in loyalty points
 CREATE TABLE IF NOT EXISTS loyalty_transactions (
@@ -123,5 +105,4 @@ $$ language 'plpgsql';
 CREATE TRIGGER update_services_updated_at BEFORE UPDATE ON services FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 CREATE TRIGGER update_branches_updated_at BEFORE UPDATE ON branches FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 CREATE TRIGGER update_customers_updated_at BEFORE UPDATE ON customers FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
-CREATE TRIGGER update_admins_updated_at BEFORE UPDATE ON admins FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 CREATE TRIGGER update_bookings_updated_at BEFORE UPDATE ON bookings FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();

--- a/scripts/01-create-tables.sql
+++ b/scripts/01-create-tables.sql
@@ -59,7 +59,7 @@ CREATE TABLE IF NOT EXISTS bookings (
   booking_date DATE NOT NULL,
   booking_time TIME NOT NULL,
   total_price INTEGER NOT NULL,
-  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'confirmed', 'in-progress', 'completed', 'cancelled')),
+  status TEXT NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'confirmed', 'picked-up', 'in-progress', 'completed', 'cancelled')),
   payment_proof TEXT,
   is_pickup_service BOOLEAN DEFAULT false,
   pickup_address TEXT,

--- a/scripts/03-seed-data.sql
+++ b/scripts/03-seed-data.sql
@@ -24,7 +24,6 @@ INSERT INTO branches (id, name, address, phone, bank_name, bank_account_number, 
 ('sukarame-branch3', 'BC Wash Sukarame Cabang 3', 'Jl. Cut Mutia No. 50, Margahayu, Bekasi Timur', '021-111222', 'BRI', '1122334455', 'BC Wash Sukarame Cab 3', '08:00', '18:00', 12, 'inactive', 'Akbar', 4)
 ON CONFLICT (id) DO NOTHING;
 
--- Seed customers data
 INSERT INTO customers (id, name, phone, email, vehicle_plate_numbers, total_loyalty_points, total_bookings, join_date) VALUES
 ('customer-001', 'Ahmad Rizki', '08123456789', 'ahmad.rizki@email.com', ARRAY['B 1234 ABC', 'B 5678 DEF'], 150, 8, '2023-06-15'),
 ('customer-002', 'Sari Dewi', '08987654321', 'sari.dewi@email.com', ARRAY['BE 9876 XYZ'], 75, 4, '2023-08-20'),
@@ -34,38 +33,27 @@ INSERT INTO customers (id, name, phone, email, vehicle_plate_numbers, total_loya
 ('customer-006', 'Rina Sari', '08222333444', 'rina.sari@email.com', ARRAY['BE 8888 STU'], 95, 5, '2023-09-18')
 ON CONFLICT (id) DO NOTHING;
 
--- Seed admins data (with hashed passwords)
--- Note: Password for all admins is 'password123' (hashed with bcrypt)
-INSERT INTO admins (id, username, name, email, password_hash, role, branch_id, is_active, last_login) VALUES
-('admin-001', 'superadmin', 'Admin Utama', 'admin@bcwash.com', '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', 'super-admin', NULL, true, '2024-01-17T08:00:00Z'),
-('admin-002', 'branch1admin', 'Budi Santoso', 'budi@bcwash.com', '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', 'branch-admin', 'sukarame-main', true, '2024-01-17T07:30:00Z'),
-('admin-003', 'branch2admin', 'Sari Indah', 'sari@bcwash.com', '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', 'branch-admin', 'sukarame-branch2', true, '2024-01-16T16:45:00Z'),
-('admin-004', 'staff001', 'Rudi Hartono', 'rudi@bcwash.com', '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', 'staff', 'sukarame-main', true, '2024-01-16T14:20:00Z'),
-('admin-005', 'staff002', 'Dewi Sartika', 'dewi@bcwash.com', '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', 'staff', 'sukarame-branch2', true, '2024-01-15T16:30:00Z'),
-('admin-006', 'branch3admin', 'Andi Wijaya', 'andi.admin@bcwash.com', '$2a$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', 'branch-admin', 'sukarame-branch3', false, '2024-01-05T15:00:00Z')
-ON CONFLICT (id) DO NOTHING;
-
 -- Seed bookings data
-INSERT INTO bookings (id, booking_code, customer_name, customer_phone, customer_email, service_id, branch_id, booking_date, booking_time, total_price, status, is_pickup_service, pickup_address, pickup_notes, vehicle_plate_number, loyalty_points_earned, loyalty_points_used, booking_source, created_by_admin, admin_user_id, payment_method, notes, created_at, updated_at) VALUES
-('booking-001', 'BCW001', 'Ahmad Rizki', '08123456789', 'ahmad.rizki@email.com', 'car-small-premium', 'sukarame-main', '2024-01-15', '10:00', 45000, 'confirmed', false, NULL, NULL, 'B 1234 ABC', 45, 0, 'online', false, NULL, 'transfer', NULL, '2024-01-14T10:00:00Z', '2024-01-14T10:30:00Z'),
+INSERT INTO bookings (id, booking_code, customer_name, customer_phone, customer_email, service_id, branch_id, booking_date, booking_time, total_price, status, is_pickup_service, pickup_address, pickup_notes, vehicle_plate_number, loyalty_points_earned, loyalty_points_used, booking_source, created_by_admin, payment_method, notes, created_at, updated_at) VALUES
+('booking-001', 'BCW001', 'Ahmad Rizki', '08123456789', 'ahmad.rizki@email.com', 'car-small-premium', 'sukarame-main', '2024-01-15', '10:00', 45000, 'confirmed', false, NULL, NULL, 'B 1234 ABC', 45, 0, 'online', false, 'transfer', NULL, '2024-01-14T10:00:00Z', '2024-01-14T10:30:00Z'),
 
-('booking-002', 'BCW002', 'Sari Dewi', '08987654321', 'sari.dewi@email.com', 'motorcycle-medium', 'sukarame-branch2', '2024-01-15', '14:00', 25000, 'pending', true, 'Jl. Raden Intan No. 789, Bandar Lampung', 'Rumah cat hijau, pagar putih', 'BE 9876 XYZ', 25, 0, 'online', false, NULL, 'transfer', NULL, '2024-01-14T14:00:00Z', '2024-01-14T14:00:00Z'),
+('booking-002', 'BCW002', 'Sari Dewi', '08987654321', 'sari.dewi@email.com', 'motorcycle-medium', 'sukarame-branch2', '2024-01-15', '14:00', 25000, 'pending', true, 'Jl. Raden Intan No. 789, Bandar Lampung', 'Rumah cat hijau, pagar putih', 'BE 9876 XYZ', 25, 0, 'online', false, 'transfer', NULL, '2024-01-14T14:00:00Z', '2024-01-14T14:00:00Z'),
 
-('booking-003', 'BCW003', 'Joko Susilo', '08111222333', 'joko.susilo@email.com', 'car-large-regular', 'sukarame-main', '2024-01-16', '09:00', 40000, 'completed', false, NULL, NULL, 'BE 5555 GHI', 40, 0, 'offline', true, 'admin-001', 'cash', 'Walk-in customer, paid cash', '2024-01-16T08:30:00Z', '2024-01-16T10:15:00Z'),
+('booking-003', 'BCW003', 'Joko Susilo', '08111222333', 'joko.susilo@email.com', 'car-large-regular', 'sukarame-main', '2024-01-16', '09:00', 40000, 'completed', false, NULL, NULL, 'BE 5555 GHI', 40, 0, 'offline', true, 'cash', 'Walk-in customer, paid cash', '2024-01-16T08:30:00Z', '2024-01-16T10:15:00Z'),
 
-('booking-004', 'BCW004', 'Maya Putri', '08444555666', 'maya.putri@email.com', 'anti-bacterial', 'sukarame-main', '2024-01-16', '11:30', 75000, 'in-progress', false, NULL, NULL, 'BE 1111 MNO', 75, 0, 'online', false, NULL, 'qris', NULL, '2024-01-16T09:00:00Z', '2024-01-16T11:30:00Z'),
+('booking-004', 'BCW004', 'Maya Putri', '08444555666', 'maya.putri@email.com', 'anti-bacterial', 'sukarame-main', '2024-01-16', '11:30', 75000, 'in-progress', false, NULL, NULL, 'BE 1111 MNO', 75, 0, 'online', false, 'qris', NULL, '2024-01-16T09:00:00Z', '2024-01-16T11:30:00Z'),
 
-('booking-005', 'BCW005', 'Andi Wijaya', '08777888999', 'andi.wijaya@email.com', 'motorcycle-small', 'sukarame-branch2', '2024-01-16', '15:00', 23000, 'cancelled', true, 'Jl. Ahmad Yani No. 456, Bandar Lampung', 'Komplek perumahan, blok C no. 12', 'B 3333 PQR', 0, 0, 'online', false, NULL, 'transfer', 'Customer cancelled due to rain', '2024-01-15T12:00:00Z', '2024-01-16T08:00:00Z'),
+('booking-005', 'BCW005', 'Andi Wijaya', '08777888999', 'andi.wijaya@email.com', 'motorcycle-small', 'sukarame-branch2', '2024-01-16', '15:00', 23000, 'cancelled', true, 'Jl. Ahmad Yani No. 456, Bandar Lampung', 'Komplek perumahan, blok C no. 12', 'B 3333 PQR', 0, 0, 'online', false, 'transfer', 'Customer cancelled due to rain', '2024-01-15T12:00:00Z', '2024-01-16T08:00:00Z'),
 
-('booking-006', 'BCW006', 'Rina Sari', '08222333444', 'rina.sari@email.com', 'car-large-premium', 'sukarame-branch2', '2024-01-17', '08:30', 50000, 'confirmed', false, NULL, NULL, 'BE 8888 STU', 50, 0, 'online', false, NULL, 'transfer', NULL, '2024-01-16T15:30:00Z', '2024-01-16T16:00:00Z'),
+('booking-006', 'BCW006', 'Rina Sari', '08222333444', 'rina.sari@email.com', 'car-large-premium', 'sukarame-branch2', '2024-01-17', '08:30', 50000, 'confirmed', false, NULL, NULL, 'BE 8888 STU', 50, 0, 'online', false, 'transfer', NULL, '2024-01-16T15:30:00Z', '2024-01-16T16:00:00Z'),
 
-('booking-007', 'BCW007', 'Budi Hartono', '08555666777', 'budi.hartono@email.com', 'glass-spot-removal', 'sukarame-main', '2024-01-17', '10:00', 75000, 'confirmed', false, NULL, NULL, 'B 9999 VWX', 75, 0, 'offline', true, 'admin-002', 'cash', 'Regular customer, requested specific staff member', '2024-01-17T07:00:00Z', '2024-01-17T07:15:00Z'),
+('booking-007', 'BCW007', 'Budi Hartono', '08555666777', 'budi.hartono@email.com', 'glass-spot-removal', 'sukarame-main', '2024-01-17', '10:00', 75000, 'confirmed', false, NULL, NULL, 'B 9999 VWX', 75, 0, 'offline', true, 'cash', 'Regular customer, requested specific staff member', '2024-01-17T07:00:00Z', '2024-01-17T07:15:00Z'),
 
-('booking-008', 'BCW008', 'Siti Nurhaliza', '08333444555', 'siti.nurhaliza@email.com', 'car-steam-quick', 'sukarame-branch2', '2024-01-17', '13:00', 45000, 'pending', true, 'Jl. Diponegoro No. 123, Bandar Lampung', 'Kantor, gedung biru lantai 2', 'BE 4444 YZA', 45, 0, 'online', false, NULL, 'transfer', NULL, '2024-01-17T08:30:00Z', '2024-01-17T08:30:00Z'),
+('booking-008', 'BCW008', 'Siti Nurhaliza', '08333444555', 'siti.nurhaliza@email.com', 'car-steam-quick', 'sukarame-branch2', '2024-01-17', '13:00', 45000, 'pending', true, 'Jl. Diponegoro No. 123, Bandar Lampung', 'Kantor, gedung biru lantai 2', 'BE 4444 YZA', 45, 0, 'online', false, 'transfer', NULL, '2024-01-17T08:30:00Z', '2024-01-17T08:30:00Z'),
 
-('booking-009', 'BCW009', 'Dedi Setiawan', '08666777888', 'dedi.setiawan@email.com', 'motorcycle-large', 'sukarame-main', '2024-01-17', '16:30', 30000, 'completed', true, 'Jl. Gatot Subroto No. 789, Bandar Lampung', 'Rumah sudut, cat kuning', 'BE 6666 BCD', 30, 0, 'offline', true, 'admin-002', 'card', 'Customer paid with debit card, service completed on time', '2024-01-17T14:00:00Z', '2024-01-17T17:00:00Z'),
+('booking-009', 'BCW009', 'Dedi Setiawan', '08666777888', 'dedi.setiawan@email.com', 'motorcycle-large', 'sukarame-main', '2024-01-17', '16:30', 30000, 'completed', true, 'Jl. Gatot Subroto No. 789, Bandar Lampung', 'Rumah sudut, cat kuning', 'BE 6666 BCD', 30, 0, 'offline', true, 'card', 'Customer paid with debit card, service completed on time', '2024-01-17T14:00:00Z', '2024-01-17T17:00:00Z'),
 
-('booking-010', 'BCW010', 'Lina Marlina', '08999000111', 'lina.marlina@email.com', 'car-small-regular', 'sukarame-branch2', '2024-01-18', '09:30', 35000, 'confirmed', false, NULL, NULL, 'B 2222 EFG', 35, 0, 'online', false, NULL, 'transfer', NULL, '2024-01-17T18:00:00Z', '2024-01-17T18:15:00Z')
+('booking-010', 'BCW010', 'Lina Marlina', '08999000111', 'lina.marlina@email.com', 'car-small-regular', 'sukarame-branch2', '2024-01-18', '09:30', 35000, 'confirmed', false, NULL, NULL, 'B 2222 EFG', 35, 0, 'online', false, 'transfer', NULL, '2024-01-17T18:00:00Z', '2024-01-17T18:15:00Z')
 ON CONFLICT (id) DO NOTHING;
 
 -- Removed sequence update commands since tables use TEXT primary keys, not auto-incrementing sequences

--- a/scripts/03-seed-data.sql
+++ b/scripts/03-seed-data.sql
@@ -49,7 +49,7 @@ INSERT INTO bookings (id, booking_code, customer_name, customer_phone, customer_
 
 ('booking-007', 'BCW007', 'Budi Hartono', '08555666777', 'budi.hartono@email.com', 'glass-spot-removal', 'sukarame-main', '2024-01-17', '10:00', 75000, 'confirmed', false, NULL, NULL, 'B 9999 VWX', 75, 0, 'offline', true, 'cash', 'Regular customer, requested specific staff member', '2024-01-17T07:00:00Z', '2024-01-17T07:15:00Z'),
 
-('booking-008', 'BCW008', 'Siti Nurhaliza', '08333444555', 'siti.nurhaliza@email.com', 'car-steam-quick', 'sukarame-branch2', '2024-01-17', '13:00', 45000, 'pending', true, 'Jl. Diponegoro No. 123, Bandar Lampung', 'Kantor, gedung biru lantai 2', 'BE 4444 YZA', 45, 0, 'online', false, 'transfer', NULL, '2024-01-17T08:30:00Z', '2024-01-17T08:30:00Z'),
+('booking-008', 'BCW008', 'Siti Nurhaliza', '08333444555', 'siti.nurhaliza@email.com', 'car-steam-quick', 'sukarame-branch2', '2024-01-17', '13:00', 45000, 'picked-up', true, 'Jl. Diponegoro No. 123, Bandar Lampung', 'Kantor, gedung biru lantai 2', 'BE 4444 YZA', 45, 0, 'online', false, 'transfer', NULL, '2024-01-17T08:30:00Z', '2024-01-17T08:30:00Z'),
 
 ('booking-009', 'BCW009', 'Dedi Setiawan', '08666777888', 'dedi.setiawan@email.com', 'motorcycle-large', 'sukarame-main', '2024-01-17', '16:30', 30000, 'completed', true, 'Jl. Gatot Subroto No. 789, Bandar Lampung', 'Rumah sudut, cat kuning', 'BE 6666 BCD', 30, 0, 'offline', true, 'card', 'Customer paid with debit card, service completed on time', '2024-01-17T14:00:00Z', '2024-01-17T17:00:00Z'),
 

--- a/scripts/generate-admin-password.ts
+++ b/scripts/generate-admin-password.ts
@@ -1,0 +1,11 @@
+import bcrypt from "bcryptjs"
+
+const password = process.argv[2]
+
+if (!password) {
+  console.error("Usage: ts-node scripts/generate-admin-password.ts <password>")
+  process.exit(1)
+}
+
+const hash = bcrypt.hashSync(password, 10)
+console.log(`Hashed password: ${hash}`)


### PR DESCRIPTION
## Summary
- remove unused admins table and references
- add CSV/PDF export on admin reports
- enable searching bookings by code, name or phone
- add script to generate hashed admin passwords

## Testing
- `pnpm lint` *(fails: Unexpected any etc.)*
- `pnpm typecheck` *(fails: various type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bd09153ea88325b3cac1b0459bb131