### PR TITLE
Track loyalty points by vehicle number

### DIFF
--- a/app/api/bookings/[id]/route.ts
+++ b/app/api/bookings/[id]/route.ts
@@ -98,7 +98,7 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
       const { data: customer } = await supabase
         .from("customers")
         .select("id, total_loyalty_points")
-        .eq("phone", existingBooking.customer_phone)
+        .contains("vehicle_plate_numbers", [existingBooking.vehicle_plate_number])
         .single()
 
       if (customer) {
@@ -111,6 +111,7 @@ export async function PUT(request: NextRequest, { params }: { params: { id: stri
 
         await supabase.from("loyalty_transactions").insert({
           customer_id: customer.id,
+          vehicle_plate_number: existingBooking.vehicle_plate_number,
           booking_id: existingBooking.id,
           points: existingBooking.loyalty_points_earned,
           type: "earn",

--- a/app/api/customers/route.ts
+++ b/app/api/customers/route.ts
@@ -1,10 +1,12 @@
 import { type NextRequest, NextResponse } from "next/server"
 import { createClient } from "@/lib/supabase/server"
+import { normalizeVehiclePlate } from "@/lib/utils"
 
 export async function GET(request: NextRequest) {
   try {
     const { searchParams } = new URL(request.url)
     const phone = searchParams.get("phone")
+    const vehiclePlate = searchParams.get("vehiclePlateNumber")
     const search = searchParams.get("search")
     const limit = searchParams.get("limit")
     const page = searchParams.get("page")
@@ -20,8 +22,14 @@ export async function GET(request: NextRequest) {
       query = query.eq("phone", phone)
     }
 
+    if (vehiclePlate) {
+      query = query.contains("vehicle_plate_numbers", [normalizeVehiclePlate(vehiclePlate)])
+    }
+
     if (search) {
-      query = query.or(`name.ilike.%${search}%,phone.ilike.%${search}%`)
+      query = query.or(
+        `name.ilike.%${search}%,phone.ilike.%${search}%,vehicle_plate_numbers::text.ilike.%${search}%`,
+      )
     }
 
     const limitNum = limit ? Number.parseInt(limit) : 10

--- a/app/api/customers/route.ts
+++ b/app/api/customers/route.ts
@@ -27,9 +27,12 @@ export async function GET(request: NextRequest) {
     }
 
     if (search) {
-      query = query.or(
-        `name.ilike.%${search}%,phone.ilike.%${search}%,vehicle_plate_numbers::text.ilike.%${search}%`,
-      )
+      const normalizedPlate = normalizeVehiclePlate(search)
+      const filters = [`name.ilike.%${search}%`, `phone.ilike.%${search}%`]
+      if (normalizedPlate) {
+        filters.push(`vehicle_plate_numbers.cs.{${normalizedPlate}}`)
+      }
+      query = query.or(filters.join(","))
     }
 
     const limitNum = limit ? Number.parseInt(limit) : 10

--- a/components/admin/manual-booking-form.tsx
+++ b/components/admin/manual-booking-form.tsx
@@ -18,7 +18,7 @@ import { Separator } from "@/components/ui/separator"
 import { User, Car, MapPin, FileText, CalendarIcon, Clock, CreditCard, X, CheckCircle } from "lucide-react"
 import { format, startOfDay } from "date-fns"
 import { id } from "date-fns/locale"
-import { cn } from "@/lib/utils"
+import { cn, normalizeVehiclePlate } from "@/lib/utils"
 import { apiClient } from "@/lib/api-client"
 import type { Service, Branch, CreateBookingData } from "@/lib/api-client"
 
@@ -333,7 +333,12 @@ export function ManualBookingForm({ onSuccess, onCancel }: ManualBookingFormProp
               <Input
                 id="vehiclePlateNumber"
                 value={formData.vehiclePlateNumber}
-                onChange={(e) => handleInputChange("vehiclePlateNumber", e.target.value.toUpperCase())}
+                onChange={(e) =>
+                  handleInputChange(
+                    "vehiclePlateNumber",
+                    normalizeVehiclePlate(e.target.value),
+                  )
+                }
                 placeholder="B 1234 ABC"
                 className={errors.vehiclePlateNumber ? "border-destructive" : ""}
               />

--- a/components/booking/customer-info.tsx
+++ b/components/booking/customer-info.tsx
@@ -11,6 +11,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { Checkbox } from "@/components/ui/checkbox"
 import { User, Phone, Mail, Car, MapPin, FileText, Clock, Info } from "lucide-react"
 import { getServiceById, type Service } from "@/lib/dummy-data"
+import { normalizeVehiclePlate } from "@/lib/utils"
 import { PickupAddressInput } from "@/components/booking/pickup-address-input"
 
 interface CustomerInfoProps {
@@ -50,7 +51,9 @@ export function CustomerInfo({
     customerName: initialData?.customerName || "",
     customerPhone: initialData?.customerPhone || "",
     customerEmail: initialData?.customerEmail || "",
-    vehiclePlateNumber: initialData?.vehiclePlateNumber || "",
+    vehiclePlateNumber: initialData?.vehiclePlateNumber
+      ? normalizeVehiclePlate(initialData.vehiclePlateNumber)
+      : "",
     isPickupService: initialData?.isPickupService || false,
     pickupAddress: initialData?.pickupAddress || "",
     pickupNotes: initialData?.pickupNotes || "",
@@ -182,7 +185,12 @@ export function CustomerInfo({
                 type="text"
                 placeholder="Contoh: B 1234 ABC"
                 value={formData.vehiclePlateNumber}
-                onChange={(e) => handleInputChange("vehiclePlateNumber", e.target.value.toUpperCase())}
+                onChange={(e) =>
+                  handleInputChange(
+                    "vehiclePlateNumber",
+                    normalizeVehiclePlate(e.target.value),
+                  )
+                }
                 className={errors.vehiclePlateNumber ? "border-destructive" : ""}
               />
               {errors.vehiclePlateNumber && <p className="text-sm text-destructive">{errors.vehiclePlateNumber}</p>}

--- a/components/booking/payment-info.tsx
+++ b/components/booking/payment-info.tsx
@@ -57,9 +57,11 @@ export function PaymentInfo({ onNext, onPrev, bookingData, updateBookingData }: 
 
   useEffect(() => {
     const fetchPoints = async () => {
-      if (bookingData.customerPhone) {
+      if (bookingData.vehiclePlateNumber) {
         try {
-          const res = await apiClient.getCustomers(bookingData.customerPhone)
+          const res = await apiClient.getCustomers({
+            vehiclePlateNumber: bookingData.vehiclePlateNumber,
+          })
           if (res.customers && res.customers.length > 0) {
             setAvailablePoints(res.customers[0].total_loyalty_points)
           }
@@ -69,7 +71,7 @@ export function PaymentInfo({ onNext, onPrev, bookingData, updateBookingData }: 
       }
     }
     fetchPoints()
-  }, [bookingData.customerPhone])
+  }, [bookingData.vehiclePlateNumber])
 
   return (
     <div className="space-y-6">

--- a/database/loyalty.sql
+++ b/database/loyalty.sql
@@ -5,6 +5,7 @@ ALTER TABLE services ADD COLUMN IF NOT EXISTS loyalty_points_reward INTEGER NOT 
 CREATE TABLE IF NOT EXISTS loyalty_transactions (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   customer_id TEXT NOT NULL,
+  vehicle_plate_number TEXT NOT NULL,
   booking_id TEXT,
   points INTEGER NOT NULL,
   type TEXT NOT NULL CHECK (type IN ('earn','redeem','adjust')),

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -385,13 +385,14 @@ class ApiClient {
   }
 
   async getCustomers(params?: {
-    phone?: string
+    vehiclePlateNumber?: string
     search?: string
     page?: number
     limit?: number
   }): Promise<{ customers: Customer[]; total: number }> {
     const searchParams = new URLSearchParams()
-    if (params?.phone) searchParams.set("phone", params.phone)
+    if (params?.vehiclePlateNumber)
+      searchParams.set("vehiclePlateNumber", params.vehiclePlateNumber)
     if (params?.search) searchParams.set("search", params.search)
     if (params?.page) searchParams.set("page", params.page.toString())
     if (params?.limit) searchParams.set("limit", params.limit.toString())

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -193,8 +193,8 @@ export const normalizePhoneNumber = (phone: string): string => {
 }
 
 export const normalizeVehiclePlate = (plate: string): string => {
-  // Normalize vehicle plate to uppercase with proper spacing
-  return plate.trim().toUpperCase().replace(/\s+/g, " ")
+  // Normalize vehicle plate to uppercase without any spaces
+  return plate.replace(/\s+/g, "").toUpperCase()
 }
 
 export const generateBookingCode = (): string => {

--- a/scripts/01-create-tables.sql
+++ b/scripts/01-create-tables.sql
@@ -86,6 +86,7 @@ CREATE INDEX IF NOT EXISTS idx_customers_phone ON customers(phone);
 CREATE TABLE IF NOT EXISTS loyalty_transactions (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   customer_id TEXT NOT NULL,
+  vehicle_plate_number TEXT NOT NULL,
   booking_id TEXT,
   points INTEGER NOT NULL,
   type TEXT NOT NULL CHECK (type IN ('earn','redeem','adjust')),


### PR DESCRIPTION
## Summary
- associate loyalty transactions with sanitized vehicle numbers instead of phone numbers
- fetch customer points via vehicle plate lookup and normalize plates by stripping spaces

## Testing
- `pnpm lint` *(fails: Unexpected any etc.)*
- `pnpm typecheck` *(fails: multiple TS2339 and TS2345 errors)*

------
https://chatgpt.com/codex/tasks/task_e_68bd398cf3008325871f5b4132cad2fa