### PR TITLE
feat: improve admin mobile responsiveness

### DIFF
--- a/app/admin/bookings/page.tsx
+++ b/app/admin/bookings/page.tsx
@@ -64,14 +64,14 @@ export default function AdminBookingsPage() {
   return (
     <AdminLayout>
       <div className="space-y-6">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <div>
             <h1 className="font-serif text-2xl md:text-3xl font-bold text-foreground">Kelola Booking</h1>
             <p className="text-muted-foreground mt-1">Kelola dan pantau semua booking pelanggan</p>
           </div>
-        <div className="flex items-center gap-2">
+        <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-2">
             <BookingExport searchTerm={filters.search} />
-            <Button asChild>
+            <Button asChild className="h-11">
               <Link href="/admin/bookings/create" className="flex items-center gap-2">
                 <Plus className="w-4 h-4" />
                 Buat Booking Manual

--- a/components/admin/admin-layout.tsx
+++ b/components/admin/admin-layout.tsx
@@ -110,7 +110,7 @@ export function AdminLayout({ children }: AdminLayoutProps) {
               <Button
                 variant="ghost"
                 onClick={handleLogout}
-                className="w-full justify-start text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+                className="w-full justify-start h-11 text-sidebar-foreground hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
               >
                 <LogOut className="w-4 h-4 mr-2" />
                 Keluar
@@ -123,17 +123,17 @@ export function AdminLayout({ children }: AdminLayoutProps) {
       </Sidebar>
 
       <SidebarInset>
-        <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
+        <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4 md:px-6">
           <SidebarTrigger className="-ml-1" />
           <Separator orientation="vertical" className="mr-2 h-4" />
-          <div className="flex items-center gap-2 text-sm">
+          <div className="flex items-center gap-2 text-sm md:text-base">
             <span className="font-medium">BC Wash Sukarame</span>
             <span className="text-muted-foreground">•</span>
             <span className="text-muted-foreground">Panel Administrasi</span>
           </div>
         </header>
 
-        <main className="flex-1 p-6">{children}</main>
+        <main className="flex-1 p-4 md:p-6">{children}</main>
       </SidebarInset>
     </SidebarProvider>
   )

--- a/components/admin/booking-export.tsx
+++ b/components/admin/booking-export.tsx
@@ -79,7 +79,7 @@ export function BookingExport({ searchTerm }: BookingExportProps) {
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        <Button disabled={isExporting} className="flex items-center gap-2">
+        <Button disabled={isExporting} className="flex items-center gap-2 h-11">
           <Download className="w-4 h-4" />
           {isExporting ? "Mengekspor..." : "Ekspor"}
         </Button>

--- a/components/admin/booking-list.tsx
+++ b/components/admin/booking-list.tsx
@@ -235,7 +235,7 @@ export function BookingList({ filters }: BookingListProps) {
           <CardTitle className="font-serif text-xl">Daftar Booking</CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="rounded-md border">
+          <div className="rounded-md border overflow-x-auto hidden md:block">
             <Table>
               <TableHeader>
                 <TableRow>
@@ -297,20 +297,20 @@ export function BookingList({ filters }: BookingListProps) {
                         <div className="flex items-center justify-end gap-2">
                           <Button
                             variant="ghost"
-                            size="sm"
+                            size="icon"
                             onClick={() => handleCallCustomer(booking)}
-                            className="h-8 w-8 p-0"
+                            className="h-11 w-11"
                           >
-                            <Phone className="h-4 w-4" />
+                            <Phone className="h-5 w-5" />
                           </Button>
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
-                              <Button variant="ghost" className="h-8 w-8 p-0" disabled={updatingStatus === booking.id}>
+                              <Button variant="ghost" className="h-11 w-11" disabled={updatingStatus === booking.id}>
                                 <span className="sr-only">Open menu</span>
                                 {updatingStatus === booking.id ? (
-                                  <Clock className="h-4 w-4 animate-spin" />
+                                  <Clock className="h-5 w-5 animate-spin" />
                                 ) : (
-                                  <MoreHorizontal className="h-4 w-4" />
+                                  <MoreHorizontal className="h-5 w-5" />
                                 )}
                               </Button>
                             </DropdownMenuTrigger>
@@ -376,17 +376,121 @@ export function BookingList({ filters }: BookingListProps) {
               </TableBody>
             </Table>
           </div>
-          <div className="flex items-center justify-between py-4">
+          <div className="space-y-4 md:hidden">
+            {bookings.length === 0 ? (
+              <div className="text-center py-8 text-muted-foreground">Belum ada booking yang tersedia</div>
+            ) : (
+              bookings.map((booking) => (
+                <div key={booking.id} className="rounded-lg border p-4 shadow-sm space-y-2">
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2 font-mono font-medium">
+                      <span>{booking.bookingCode}</span>
+                      {booking.paymentProof && <FileImage className="h-4 w-4 text-primary" />}
+                    </div>
+                    {getStatusBadge(booking.status)}
+                  </div>
+                  <div>
+                    <p className="font-medium">{booking.customerName}</p>
+                    <p className="text-sm text-muted-foreground">{booking.customerPhone}</p>
+                  </div>
+                  <div className="text-sm text-muted-foreground">
+                    <p>{booking.service}</p>
+                    <p>{booking.branch}</p>
+                    <p>
+                      {format(booking.date ? new Date(booking.date + "T00:00:00") : new Date(), "dd MMM yyyy", { locale: id })} • {booking.time} WIB
+                    </p>
+                  </div>
+                  <div className="flex items-center justify-between pt-2">
+                    <span className="font-medium">{formatCurrency(booking.totalPrice)}</span>
+                    <div className="flex items-center gap-2">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => handleCallCustomer(booking)}
+                        className="h-11 w-11"
+                      >
+                        <Phone className="h-5 w-5" />
+                      </Button>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button variant="ghost" className="h-11 w-11" disabled={updatingStatus === booking.id}>
+                            <span className="sr-only">Open menu</span>
+                            {updatingStatus === booking.id ? (
+                              <Clock className="h-5 w-5 animate-spin" />
+                            ) : (
+                              <MoreHorizontal className="h-5 w-5" />
+                            )}
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end">
+                          <DropdownMenuLabel>Aksi</DropdownMenuLabel>
+                          <DropdownMenuItem onClick={() => handleViewDetails(booking)}>
+                            <Eye className="mr-2 h-4 w-4" />
+                            Lihat Detail
+                          </DropdownMenuItem>
+                          {booking.paymentProof && (
+                            <DropdownMenuItem onClick={() => handleViewDetails(booking)}>
+                              <FileImage className="mr-2 h-4 w-4" />
+                              Lihat Bukti Pembayaran
+                            </DropdownMenuItem>
+                          )}
+                          <DropdownMenuSeparator />
+                          {booking.status === "pending" && (
+                            <DropdownMenuItem onClick={() => handleStatusChange(booking.id, "confirmed")}>
+                              <CheckCircle className="mr-2 h-4 w-4" />
+                              Konfirmasi
+                            </DropdownMenuItem>
+                          )}
+                          {booking.status === "confirmed" && booking.isPickupService && (
+                            <DropdownMenuItem onClick={() => handleStatusChange(booking.id, "picked-up")}>
+                              <Car className="mr-2 h-4 w-4" />
+                              Jemput
+                            </DropdownMenuItem>
+                          )}
+                          {booking.status === "confirmed" && !booking.isPickupService && (
+                            <DropdownMenuItem onClick={() => handleStatusChange(booking.id, "in-progress")}>
+                              <Clock className="mr-2 h-4 w-4" />
+                              Mulai Layanan
+                            </DropdownMenuItem>
+                          )}
+                          {booking.status === "picked-up" && (
+                            <DropdownMenuItem onClick={() => handleStatusChange(booking.id, "in-progress")}>
+                              <Clock className="mr-2 h-4 w-4" />
+                              Mulai Layanan
+                            </DropdownMenuItem>
+                          )}
+                          {booking.status === "in-progress" && (
+                            <DropdownMenuItem onClick={() => handleStatusChange(booking.id, "completed")}>
+                              <CheckCircle className="mr-2 h-4 w-4" />
+                              Selesaikan
+                            </DropdownMenuItem>
+                          )}
+                          {(booking.status === "pending" || booking.status === "confirmed" || booking.status === "picked-up") && (
+                            <DropdownMenuItem onClick={() => handleStatusChange(booking.id, "cancelled")} className="text-red-600">
+                              <XCircle className="mr-2 h-4 w-4" />
+                              Batalkan
+                            </DropdownMenuItem>
+                          )}
+                        </DropdownMenuContent>
+                      </DropdownMenu>
+                    </div>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between py-4 gap-4">
             <div className="text-sm text-muted-foreground">
               Menampilkan {bookings.length ? (page - 1) * pageSize + 1 : 0}-
               {(page - 1) * pageSize + bookings.length} dari {total} booking
             </div>
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-2 sm:justify-end">
               <Button
                 variant="outline"
                 size="sm"
                 onClick={() => setPage(page - 1)}
                 disabled={page === 1}
+                className="h-11"
               >
                 Sebelumnya
               </Button>
@@ -398,6 +502,7 @@ export function BookingList({ filters }: BookingListProps) {
                 size="sm"
                 onClick={() => setPage(page + 1)}
                 disabled={page >= Math.ceil(total / pageSize)}
+                className="h-11"
               >
                 Selanjutnya
               </Button>

--- a/components/admin/service-management.tsx
+++ b/components/admin/service-management.tsx
@@ -164,7 +164,7 @@ export function ServiceManagement() {
   if (loading) {
     return (
       <div className="space-y-6">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <div>
             <h1 className="font-serif text-2xl md:text-3xl font-bold text-foreground">Kelola Layanan</h1>
             <p className="text-muted-foreground mt-1">Memuat data layanan...</p>
@@ -188,7 +188,7 @@ export function ServiceManagement() {
   if (error) {
     return (
       <div className="space-y-6">
-        <div className="flex items-center justify-between">
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
           <div>
             <h1 className="font-serif text-2xl md:text-3xl font-bold text-foreground">Kelola Layanan</h1>
             <p className="text-muted-foreground mt-1">Kelola semua layanan yang tersedia di seluruh cabang</p>
@@ -205,7 +205,7 @@ export function ServiceManagement() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
         <div>
           <h1 className="font-serif text-2xl md:text-3xl font-bold text-foreground">Kelola Layanan</h1>
           <p className="text-muted-foreground mt-1">Kelola semua layanan yang tersedia di seluruh cabang</p>
@@ -213,7 +213,7 @@ export function ServiceManagement() {
         <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>
           <DialogTrigger asChild>
             {/* <Button onClick={resetForm}> */}
-            <Button>
+            <Button className="h-11">
               <Plus className="w-4 h-4 mr-2" />
               Tambah Layanan
             </Button>
@@ -254,8 +254,10 @@ export function ServiceManagement() {
                 Belum ada layanan yang tersedia. Tambahkan layanan pertama Anda.
               </div>
             ) : (
-              <Table>
-                <TableHeader>
+              <>
+                <div className="hidden md:block overflow-x-auto">
+                  <Table>
+                    <TableHeader>
                   <TableRow>
                     <TableHead>Layanan</TableHead>
                     <TableHead>Kategori</TableHead>
@@ -267,8 +269,8 @@ export function ServiceManagement() {
                     <TableHead className="text-right">Aksi</TableHead>
                   </TableRow>
                 </TableHeader>
-                <TableBody>
-                  {serviceList.filter(service => service.is_active).map((service) => {
+                    <TableBody>
+                      {serviceList.filter(service => service.is_active).map((service) => {
                     const IconComponent = getCategoryIcon(service.category)
                     return (
                       <TableRow key={service.id}>
@@ -336,13 +338,18 @@ export function ServiceManagement() {
                         </TableCell>
                         <TableCell className="text-right">
                           <div className="flex items-center justify-end gap-2">
-                            <Button variant="ghost" size="sm" onClick={() => handleEditService(service)}>
-                              <Edit className="w-4 h-4" />
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => handleEditService(service)}
+                              className="h-11 w-11"
+                            >
+                              <Edit className="w-5 h-5" />
                             </Button>
                             <AlertDialog>
                               <AlertDialogTrigger asChild>
-                                <Button variant="ghost" size="sm">
-                                  <Trash2 className="w-4 h-4 text-red-500" />
+                                <Button variant="ghost" size="icon" className="h-11 w-11">
+                                  <Trash2 className="w-5 h-5 text-red-500" />
                                 </Button>
                               </AlertDialogTrigger>
                               <AlertDialogContent>
@@ -368,9 +375,107 @@ export function ServiceManagement() {
                         </TableCell>
                       </TableRow>
                     )
+                      })}
+                    </TableBody>
+                  </Table>
+                </div>
+                <div className="space-y-4 md:hidden">
+                  {serviceList.filter(service => service.is_active).map((service) => {
+                    const IconComponent = getCategoryIcon(service.category)
+                    return (
+                      <div key={service.id} className="rounded-lg border p-4 shadow-sm space-y-2">
+                        <div className="flex items-start justify-between">
+                          <div>
+                            <p className="font-medium">{service.name}</p>
+                            <p className="text-sm text-muted-foreground">{service.description}</p>
+                            {service.features && service.features.length > 0 && (
+                              <div className="flex flex-wrap gap-1 mt-1">
+                                {service.features.map((feature, index) => (
+                                  <Badge key={index} variant="secondary" className="text-xs">
+                                    {feature}
+                                  </Badge>
+                                ))}
+                              </div>
+                            )}
+                          </div>
+                          <Badge className={getCategoryColor(service.category)}>
+                            <IconComponent className="w-3 h-3 mr-1" />
+                            {getCategoryName(service.category)}
+                          </Badge>
+                        </div>
+                        <div className="text-sm text-muted-foreground space-y-1">
+                          <div className="flex items-center gap-1">
+                            <DollarSign className="w-3 h-3 text-muted-foreground" />
+                            {formatCurrency(service.price)}
+                          </div>
+                          <div className="flex items-center gap-1">
+                            <Clock className="w-3 h-3 text-muted-foreground" />
+                            {service.duration} menit
+                          </div>
+                          <div className="flex items-center gap-1">
+                            <Star className="w-3 h-3 text-yellow-500" />
+                            {service.loyalty_points_reward ?? 0}
+                          </div>
+                          <div className="flex items-center gap-1">
+                            <MapPin className="w-3 h-3 text-muted-foreground" />
+                            {service.supports_pickup ? (
+                              <span className="text-green-600">Ya ({formatCurrency(service.pickup_fee || 0)})</span>
+                            ) : (
+                              <span className="text-muted-foreground">Tidak</span>
+                            )}
+                          </div>
+                        </div>
+                        <div className="flex items-center justify-between pt-2">
+                          {service.is_active ? (
+                            <Badge variant="outline" className="bg-green-50 text-green-700 border-green-200">
+                              Aktif
+                            </Badge>
+                          ) : (
+                            <Badge variant="outline" className="bg-red-50 text-red-700 border-red-200">
+                              Non-Aktif
+                            </Badge>
+                          )}
+                          <div className="flex items-center gap-2">
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              onClick={() => handleEditService(service)}
+                              className="h-11 w-11"
+                            >
+                              <Edit className="w-5 h-5" />
+                            </Button>
+                            <AlertDialog>
+                              <AlertDialogTrigger asChild>
+                                <Button variant="ghost" size="icon" className="h-11 w-11">
+                                  <Trash2 className="w-5 h-5 text-red-500" />
+                                </Button>
+                              </AlertDialogTrigger>
+                              <AlertDialogContent>
+                                <AlertDialogHeader>
+                                  <AlertDialogTitle>Hapus Layanan</AlertDialogTitle>
+                                  <AlertDialogDescription>
+                                    Apakah Anda yakin ingin menghapus layanan "{service.name}"? Tindakan ini tidak dapat
+                                    dibatalkan dan akan mempengaruhi semua cabang.
+                                  </AlertDialogDescription>
+                                </AlertDialogHeader>
+                                <AlertDialogFooter>
+                                  <AlertDialogCancel>Batal</AlertDialogCancel>
+                                  <AlertDialogAction
+                                    onClick={() => handleDeleteService(service)}
+                                    className="bg-red-600 hover:bg-red-700"
+                                  >
+                                    Hapus
+                                  </AlertDialogAction>
+                                </AlertDialogFooter>
+                              </AlertDialogContent>
+                            </AlertDialog>
+                          </div>
+                        </div>
+                      </div>
+                    )
                   })}
-                </TableBody>
-              </Table>
+                </div>
+              </>
             )}
           </CardContent>
         </Card>

--- a/components/ui/sidebar.tsx
+++ b/components/ui/sidebar.tsx
@@ -3,7 +3,7 @@
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { type VariantProps, cva } from "class-variance-authority"
-import { PanelLeft } from "lucide-react"
+import { Menu } from "lucide-react"
 
 import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"
@@ -226,14 +226,14 @@ const SidebarTrigger = React.forwardRef<React.ElementRef<typeof Button>, React.C
         data-sidebar="trigger"
         variant="ghost"
         size="icon"
-        className={cn("h-7 w-7", className)}
+        className={cn("h-11 w-11 md:h-9 md:w-9", className)}
         onClick={(event) => {
           onClick?.(event)
           toggleSidebar()
         }}
         {...props}
       >
-        <PanelLeft />
+        <Menu />
         <span className="sr-only">Toggle Sidebar</span>
       </Button>
     )


### PR DESCRIPTION
## Summary
- redesign admin sidebar trigger as larger hamburger menu
- make admin layout and buttons responsive for small screens
- replace table-heavy views with scrollable tables on desktop and card layout on mobile

## Testing
- `pnpm lint` *(fails: Unexpected any and other pre-existing lint errors)*
- `pnpm typecheck` *(fails: various type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68bd80b7237483259c7f0fcfdba36b67