### PR TITLE
feat: add endpoint to generate admin password hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ URL Vercel Project: https://vercel.com/abamakbar07s-projects/v0-bc-wash-sukarame
 
 Gunakan endpoint berikut untuk membuat hash bcrypt untuk password admin baru:
 
+- **GET** `/api/generate-password?password=yourPlainPassword`
+  - Response: `{ "hash": "<bcrypt hash>" }`
 - **POST** `/api/generate-password`
   - Body: `{ "password": "yourPlainPassword" }`
   - Response: `{ "hash": "<bcrypt hash>" }`

--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ URL Vercel Project: https://vercel.com/abamakbar07s-projects/v0-bc-wash-sukarame
 - `pnpm start` — Jalankan build produksi
 - `pnpm lint` — Linting (non-blocking di build config)
 
+## Generate Admin Password Hash
+
+Gunakan endpoint berikut untuk membuat hash bcrypt untuk password admin baru:
+
+- **POST** `/api/generate-password`
+  - Body: `{ "password": "yourPlainPassword" }`
+  - Response: `{ "hash": "<bcrypt hash>" }`
+
+Salin nilai `hash` ke `ADMIN_PASSWORD_HASH` di `.env.local` Anda.
+
 ## Catatan & Keamanan
 
 - Jangan commit kredensial rahasia (`.env.local`) ke repository publik

--- a/app/api/generate-password/route.ts
+++ b/app/api/generate-password/route.ts
@@ -1,6 +1,27 @@
 import { type NextRequest, NextResponse } from "next/server"
 import bcrypt from "bcryptjs"
 
+async function hashPassword(password: string) {
+  return bcrypt.hash(password, 10)
+}
+
+export async function GET(request: NextRequest) {
+  try {
+    const { searchParams } = new URL(request.url)
+    const password = searchParams.get("password")
+
+    if (!password) {
+      return NextResponse.json({ error: "Password query parameter is required" }, { status: 400 })
+    }
+
+    const hash = await hashPassword(password)
+    return NextResponse.json({ hash })
+  } catch (error) {
+    console.error("Password hash generation error:", error)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}
+
 export async function POST(request: NextRequest) {
   try {
     const { password } = await request.json()
@@ -9,7 +30,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ error: "Password is required" }, { status: 400 })
     }
 
-    const hash = await bcrypt.hash(password, 10)
+    const hash = await hashPassword(password)
 
     return NextResponse.json({ hash })
   } catch (error) {

--- a/app/api/generate-password/route.ts
+++ b/app/api/generate-password/route.ts
@@ -1,0 +1,19 @@
+import { type NextRequest, NextResponse } from "next/server"
+import bcrypt from "bcryptjs"
+
+export async function POST(request: NextRequest) {
+  try {
+    const { password } = await request.json()
+
+    if (!password) {
+      return NextResponse.json({ error: "Password is required" }, { status: 400 })
+    }
+
+    const hash = await bcrypt.hash(password, 10)
+
+    return NextResponse.json({ hash })
+  } catch (error) {
+    console.error("Password hash generation error:", error)
+    return NextResponse.json({ error: "Internal server error" }, { status: 500 })
+  }
+}


### PR DESCRIPTION
## Summary
- add API route to generate bcrypt hash for admin password
- document new /api/generate-password endpoint in README

## Testing
- `pnpm lint` *(fails: Unexpected any and other lint issues across repository)*
- `pnpm typecheck` *(fails: Type errors across repository)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9f58b73c832580992993ca75753d