### PR TITLE
Handle booked time slots on booking page

### DIFF
--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -75,6 +75,7 @@ export async function GET(request: NextRequest) {
     const limit = searchParams.get("limit")
     const page = searchParams.get("page")
     const search = searchParams.get("search")
+    const getAll = searchParams.get("all") === "true"
 
     const supabase = createClient()
     let query = supabase
@@ -107,11 +108,13 @@ export async function GET(request: NextRequest) {
       query = query.lte("booking_date", dateTo)
     }
 
-    const limitNum = limit ? Number.parseInt(limit) : 10
-    const pageNum = page ? Number.parseInt(page) : 1
-    const from = (pageNum - 1) * limitNum
-    const to = from + limitNum - 1
-    query = query.range(from, to)
+    if (!getAll) {
+      const limitNum = limit ? Number.parseInt(limit) : 10
+      const pageNum = page ? Number.parseInt(page) : 1
+      const from = (pageNum - 1) * limitNum
+      const to = from + limitNum - 1
+      query = query.range(from, to)
+    }
 
     if (search) {
       query = query.or(

--- a/lib/api-client.ts
+++ b/lib/api-client.ts
@@ -213,6 +213,7 @@ class ApiClient {
     limit?: number
     page?: number
     search?: string
+    all?: boolean
   }): Promise<{ bookings: Booking[]; total: number }> {
     try {
       const searchParams = new URLSearchParams()
@@ -224,6 +225,7 @@ class ApiClient {
       if (params?.limit) searchParams.set("limit", params.limit.toString())
       if (params?.page) searchParams.set("page", params.page.toString())
       if (params?.search) searchParams.set("search", params.search)
+      if (params?.all) searchParams.set("all", "true")
 
       const query = searchParams.toString()
       const result = await this.request<{ bookings: Booking[]; total: number }>(


### PR DESCRIPTION
## Summary
- allow fetching all bookings without pagination via API query flag to support availability checks
- load booked slots for a selected branch and date and clear invalid selections
- disable already-booked time buttons while showing loading feedback when availability is being fetched

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692470fafdc883259fd90b2b87c382d3)