### PR TITLE
Normalize booking time format for timeslot checks

### DIFF
--- a/components/booking/branch-time-selection.tsx
+++ b/components/booking/branch-time-selection.tsx
@@ -124,6 +124,12 @@ export function BranchTimeSelection({
     }
   }
 
+  const formatBookingTime = (time: string) => {
+    const [hours, minutes] = time.split(":")
+    if (!hours || !minutes) return time
+    return `${hours.padStart(2, "0")}:${minutes.padStart(2, "0")}`
+  }
+
   const loadBranchBookings = async (branchId: string) => {
     try {
       setBookingsLoading(true)
@@ -135,11 +141,12 @@ export function BranchTimeSelection({
 
       const groupedBookings = bookings.reduce<Record<string, string[]>>((acc, booking) => {
         const dateKey = booking.booking_date
+        const bookingTime = formatBookingTime(booking.booking_time)
         if (!acc[dateKey]) {
           acc[dateKey] = []
         }
-        if (!acc[dateKey].includes(booking.booking_time)) {
-          acc[dateKey].push(booking.booking_time)
+        if (!acc[dateKey].includes(bookingTime)) {
+          acc[dateKey].push(bookingTime)
         }
         return acc
       }, {})


### PR DESCRIPTION
## Summary
- normalize booking times returned from API before grouping them by date
- ensure existing bookings with seconds-based time strings block the correct slots

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692483296d40832591e2b0b9442130a2)